### PR TITLE
Add Clone method

### DIFF
--- a/api.go
+++ b/api.go
@@ -106,7 +106,7 @@ func (h *Hasher) Reset() {
 //
 // Modifying the resulting Hasher will not modify the original Hasher, and vice versa.
 func (h *Hasher) Clone() *Hasher {
-	return &Hasher{size: h.size, h: h.h.clone()}
+	return &Hasher{size: h.size, h: h.h}
 }
 
 // Size implements part of the hash.Hash interface. It returns the number of

--- a/api.go
+++ b/api.go
@@ -102,6 +102,13 @@ func (h *Hasher) Reset() {
 	h.h.reset()
 }
 
+// Clone returns a new Hasher with the same internal state.
+//
+// Modifying the resulting Hasher will not modify the original Hasher, and vice versa.
+func (h *Hasher) Clone() *Hasher {
+	return &Hasher{size: h.size, h: h.h.clone()}
+}
+
 // Size implements part of the hash.Hash interface. It returns the number of
 // bytes the hash will output in Sum.
 func (h *Hasher) Size() int {

--- a/api_test.go
+++ b/api_test.go
@@ -268,3 +268,19 @@ func TestSum512(t *testing.T) {
 		assert.Equal(t, hex.EncodeToString(got[:]), hex.EncodeToString(exp[:]))
 	}
 }
+
+func TestClone(t *testing.T) {
+	key := make([]byte, 32)
+	for i := 0; i < len(key); i++ {
+		key[i] = byte(i)
+	}
+	h, _ := NewKeyed(key)
+	_, _ = h.Write([]byte{0x1})
+	sum1 := h.Sum(nil)
+	assert.Equal(t, hex.EncodeToString(sum1), hex.EncodeToString(h.Clone().Sum(nil)))
+	h2 := h.Clone()
+	h2.Write([]byte{0x2})
+	assert.Equal(t, hex.EncodeToString(sum1), hex.EncodeToString(h.Sum(nil)))
+	h.Write([]byte{0x2})
+	assert.Equal(t, hex.EncodeToString(h.Sum(nil)), hex.EncodeToString(h2.Sum(nil)))
+}

--- a/blake3.go
+++ b/blake3.go
@@ -30,17 +30,6 @@ func (a *hasher) reset() {
 	a.stack.bufn = 0
 }
 
-func (a *hasher) clone() hasher {
-	var out hasher
-	out.len = a.len
-	out.chunks = a.chunks
-	out.flags = a.flags
-	copy(out.key[:], a.key[:])
-	out.stack = a.stack.clone()
-	copy(out.buf[:], a.buf[:])
-	return out
-}
-
 func (a *hasher) update(buf []byte) {
 	// relies on the first two words of a string being the same as a slice
 	a.updateString(*(*string)(unsafe.Pointer(&buf)))
@@ -160,16 +149,6 @@ type cvstack struct {
 	bufn  int      // how many pairs are loaded into buf
 	buf   [2]chainVector
 	stack [64][8]uint32
-}
-
-func (a *cvstack) clone() cvstack {
-	var out cvstack
-	out.occ = a.occ
-	copy(out.lvls[:], a.lvls[:])
-	out.bufn = a.bufn
-	copy(out.buf[:], a.buf[:])
-	copy(out.stack[:], a.stack[:])
-	return out
 }
 
 func (a *cvstack) pushN(l uint8, cv *chainVector, n int, flags uint32, key *[8]uint32) {

--- a/blake3.go
+++ b/blake3.go
@@ -30,6 +30,17 @@ func (a *hasher) reset() {
 	a.stack.bufn = 0
 }
 
+func (a *hasher) clone() hasher {
+	var out hasher
+	out.len = a.len
+	out.chunks = a.chunks
+	out.flags = a.flags
+	copy(out.key[:], a.key[:])
+	out.stack = a.stack.clone()
+	copy(out.buf[:], a.buf[:])
+	return out
+}
+
 func (a *hasher) update(buf []byte) {
 	// relies on the first two words of a string being the same as a slice
 	a.updateString(*(*string)(unsafe.Pointer(&buf)))
@@ -149,6 +160,16 @@ type cvstack struct {
 	bufn  int      // how many pairs are loaded into buf
 	buf   [2]chainVector
 	stack [64][8]uint32
+}
+
+func (a *cvstack) clone() cvstack {
+	var out cvstack
+	out.occ = a.occ
+	copy(out.lvls[:], a.lvls[:])
+	out.bufn = a.bufn
+	copy(out.buf[:], a.buf[:])
+	copy(out.stack[:], a.stack[:])
+	return out
 }
 
 func (a *cvstack) pushN(l uint8, cv *chainVector, n int, flags uint32, key *[8]uint32) {


### PR DESCRIPTION
## What

This adds a simple `.Clone()` method to the `Hasher` struct. This returns a new `Hasher` with the same internal state. This allows users to easily write out new data to a given hash without mutating it.

## Why

This is extremely useful when using BLAKE3 as an XOF. A common pattern is to run a protocol, feeding in information
to the hash, and using the current state as a random oracle from time to time. With this usage, you sometimes want to "branch off" and create multiple hashes with the same parent state, but which take in different input after that.

For example, we use this pattern a lot in https://github.com/taurusgroup/cmp-ecdsa.

Note that the Rust reference implementation has this functionality (`Hasher` implements `Clone`):
https://docs.rs/blake3/1.0.0/blake3/struct.Hasher.html

## How

To clone a `Hasher`, this PR clones its internal stack based structs. It does this by simply writing out the fields, and copying over the arrays.

There's also a simple test making sure that cloning and then writing doesn't mutate the original hash, and that it's possible to "resync" the original hash with a cloned version.