### PR TITLE
Change BlockSize to 64. Fixes #19

### DIFF
--- a/api.go
+++ b/api.go
@@ -118,8 +118,7 @@ func (h *Hasher) Size() int {
 // BlockSize implements part of the hash.Hash interface. It returns the most
 // natural size to write to the Hasher.
 func (h *Hasher) BlockSize() int {
-	// TODO: is there a downside to picking this large size?
-	return 8192
+	return 64
 }
 
 // Sum implements part of the hash.Hash interface. It appends the digest of


### PR DESCRIPTION
BLAKE3 block size is defined as 64 bytes by specification.