### PR TITLE
New512() api to satisfy stdlib hash.Hash

### DIFF
--- a/api.go
+++ b/api.go
@@ -26,6 +26,16 @@ func New() *Hasher {
 	}
 }
 
+// New512 returns a new Hasher that has a digest size of 64 byties.
+func New512() *Hasher {
+	return &Hasher{
+		size: 64,
+		h: hasher{
+			key: consts.IV,
+		},
+	}
+}
+
 // NewKeyed returns a new Hasher that uses the 32 byte input key and has
 // a digest size of 32 bytes.
 //


### PR DESCRIPTION
Hello Jeff, 
would it be possible to add a New512() additional api?

Rationale:

Via Digest() Interface it is possible to extract custom sizes, but Digest() is not compatible with the golang stdlib hash.Hasher Interface.

Because the Hasher{size} is not exposed, it is currently impossible 
to get manually a hash.Hash Blake3-512 via zeebo/blake3.

All stdlib, golang.org/x/crypto and 3rdParty KDF func (pbkdf2, scrypt, ...) support the golang universal stdlib hash.Hasher interface.

This commit would allow to satisify the hash.Hash interface for almost all (99%) use cases.

References:
For example lukechampine/blake3 implementation, allows for this use case custom hash.Hash sizes via 
=> func New(size int, key []byte) *Hasher {...}

Thank you! 
Michael