### PR TITLE
Added support for SumTo

### DIFF
--- a/api.go
+++ b/api.go
@@ -134,6 +134,12 @@ func (h *Hasher) Sum(b []byte) []byte {
 	return append(b, tmp...)
 }
 
+// Copy the digest of the Hasher to the provided buffer and return bytes copied.
+func (h *Hasher) SumTo(b []byte) int {
+	h.h.finalize(b)
+	return h.size
+}
+
 // Digest takes a snapshot of the hash state and returns an object that can
 // be used to read and seek through 2^64 bytes of digest output.
 func (h *Hasher) Digest() *Digest {


### PR DESCRIPTION
Although it's not part of the `hash.Hash` interface, I had an existing `[32]byte` and wanted to write the digest directly to it.

```go
type Message struct {
    Payload   [32]byte
    Signature [32]byte
}

func main() {
    var msg Message
    key := make([]byte, 32)
    h, _ := blake3.NewKeyed(key)

    h.Write(msg.Payload[:])
    h.SumTo(msg.Signature[:])
}
```

